### PR TITLE
ci: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,49 @@
+version: 2
+
+updates:
+  # GitHub Actions used by the build workflows
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - github-actions
+    commit-message:
+      prefix: "ci"
+
+  # Electron / TypeScript app dependencies
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - javascript
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore(dev)"
+      include: scope
+
+  # Python bridge dependencies
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - python
+    commit-message:
+      prefix: "chore"
+      include: scope
+
+  # arraybeam submodule
+  - package-ecosystem: gitsubmodule
+    directory: "/"
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - submodules
+    commit-message:
+      prefix: "chore"


### PR DESCRIPTION
Enable weekly Dependabot updates for GitHub Actions, npm, pip, and the
arraybeam git submodule.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017HZZ27mS1srm2baWq3QLAp